### PR TITLE
❄️ Rebuild using libxml2 2.13.1 ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1d193e9cf11766a394722e1899d6a7d1fb81387af113250beff58e6325851b13
 
 build:
-  number: 1
+  number: 2
   # geotiff, libgdal=3.0, ceres-solver (and its dependencies suitesparse, gflags, glog, eigen) are not available on s390x
   skip: true  # [s390x]
   run_exports:
@@ -34,7 +34,7 @@ requirements:
     - intel-openmp   {{ mkl }}        # [blas_impl == "mkl"]
     # required packages
     - ceres-solver 2.1.0
-    - libcurl 7.88.1
+    - libcurl {{ libcurl }}
     - draco 1.5.6
     - geotiff 1.7.0
     - hdf5 1.12.1
@@ -48,7 +48,7 @@ requirements:
     - xerces-c 3.2.4
     # optional packages: also glog and gflags from ceres-solver
     - eigen 3.3.7
-    - libxml2 2.10
+    - libxml2 {{ libxml2 }}
     - openssl {{ openssl }}
     - zstd 1.5.2
   run:
@@ -56,7 +56,7 @@ requirements:
     - mkl {{ mkl }}.*                 # [blas_impl == "mkl"]
     - {{ pin_compatible('intel-openmp') }}   # [blas_impl == "mkl"]
     - ceres-solver >=2.1.0,<2.2.0a0
-    - libcurl >=7.88.1,<8.0.0a0
+    - libcurl
     - draco >=1.5.6,<1.6.0a0
     - eigen >=3.3.7,<3.3.8.0a0
     - geotiff >=1.7.0,<1.8.0a0
@@ -64,7 +64,7 @@ requirements:
     - libgdal >=3.6.2,<3.7.0a0
     - libkml >=1.3.0,<1.4.0a0
     - libpq >=12.15,<13.0a0
-    - libxml2 >=2.10.3,<2.11.0a0
+    - libxml2
     - nitro >=2.7.dev6,<2.8.0a0
     - openssl  # exact pin handled through openssl run_exports
     - tiledb >=2.3.3,<2.4.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,9 @@ package:
 source:
   url: https://github.com/PDAL/PDAL/releases/download/{{ version }}/PDAL-{{ version }}-src.tar.bz2
   sha256: 1d193e9cf11766a394722e1899d6a7d1fb81387af113250beff58e6325851b13
+  patches:
+    # https://github.com/PDAL/PDAL/pull/4257
+    - patches/0001_Fix_xmlErrorPtr.patch
 
 build:
   number: 2
@@ -26,6 +29,8 @@ requirements:
     - ninja
     - pkg-config
     - libcxx =14  # [osx]
+    - patch  # [unix]
+    - m2-patch  # [win]
   host:
     - blas  # [win]
     - mkl-devel {{ mkl }}.*           # [blas_impl == "mkl"]

--- a/recipe/patches/0001_Fix_xmlErrorPtr.patch
+++ b/recipe/patches/0001_Fix_xmlErrorPtr.patch
@@ -1,0 +1,58 @@
+From a13d70254ef1c0788f584aeb5ec25392fe9f8497 Mon Sep 17 00:00:00 2001
+From: Steven <scrass@anaconda.com>
+Date: Thu, 8 Aug 2024 10:22:57 -0600
+Subject: [PATCH] update XMLSchema.cpp
+
+---
+ pdal/XMLSchema.cpp | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/pdal/XMLSchema.cpp b/pdal/XMLSchema.cpp
+index 81d62a6..9019a06 100644
+--- a/pdal/XMLSchema.cpp
++++ b/pdal/XMLSchema.cpp
+@@ -73,7 +73,11 @@ namespace pdal
+ {
+ 
+ void SchemaStructuredErrorHandler
++#if LIBXML_VERSION >= 21200
++(void * /*userData*/, const xmlError *error)
++#else
+ (void * /*userData*/, xmlErrorPtr error)
++#endif
+ {
+     std::ostringstream oss;
+ 
+@@ -98,14 +102,22 @@ void SchemaStructuredErrorHandler
+ }
+ 
+ void SchemaParserStructuredErrorHandler
++#if LIBXML_VERSION >= 21200
++(void * /*userData*/, const xmlError *error)
++#else
+ (void * /*userData*/, xmlErrorPtr error)
++#endif
+ {
+     std::cerr << "Schema parsing error: '" << error->message << "' " <<
+         "on line " << error->line << std::endl;
+ }
+ 
+ void SchemaValidationStructuredErrorHandler
++#if LIBXML_VERSION >= 21200
++(void * /*userData*/, const xmlError *error)
++#else
+ (void * /*userData*/, xmlErrorPtr error)
++#endif
+ {
+     std::cerr << "Schema validation error: '" << error->message << "' " <<
+         "on line " << error->line << std::endl;
+@@ -646,4 +658,4 @@ void XMLSchema::writeXml(xmlTextWriterPtr w) const
+     xmlTextWriterFlush(w);
+ }
+ 
+-} // namespace pdal
++} // namespace pdal
+\ No newline at end of file
+-- 
+2.39.3 (Apple Git-145)
+

--- a/recipe/patches/0001_Fix_xmlErrorPtr.patch
+++ b/recipe/patches/0001_Fix_xmlErrorPtr.patch
@@ -1,7 +1,7 @@
 From a13d70254ef1c0788f584aeb5ec25392fe9f8497 Mon Sep 17 00:00:00 2001
 From: Steven <scrass@anaconda.com>
 Date: Thu, 8 Aug 2024 10:22:57 -0600
-Subject: [PATCH] update XMLSchema.cpp
+Subject: [PATCH] Fix convention error with xmlErrorPtr caused by libxml2 API change
 
 ---
  pdal/XMLSchema.cpp | 14 +++++++++++++-
@@ -13,7 +13,7 @@ index 81d62a6..9019a06 100644
 +++ b/pdal/XMLSchema.cpp
 @@ -73,7 +73,11 @@ namespace pdal
  {
- 
+
  void SchemaStructuredErrorHandler
 +#if LIBXML_VERSION >= 21200
 +(void * /*userData*/, const xmlError *error)
@@ -22,10 +22,10 @@ index 81d62a6..9019a06 100644
 +#endif
  {
      std::ostringstream oss;
- 
+
 @@ -98,14 +102,22 @@ void SchemaStructuredErrorHandler
  }
- 
+
  void SchemaParserStructuredErrorHandler
 +#if LIBXML_VERSION >= 21200
 +(void * /*userData*/, const xmlError *error)
@@ -36,7 +36,7 @@ index 81d62a6..9019a06 100644
      std::cerr << "Schema parsing error: '" << error->message << "' " <<
          "on line " << error->line << std::endl;
  }
- 
+
  void SchemaValidationStructuredErrorHandler
 +#if LIBXML_VERSION >= 21200
 +(void * /*userData*/, const xmlError *error)
@@ -49,10 +49,10 @@ index 81d62a6..9019a06 100644
 @@ -646,4 +658,4 @@ void XMLSchema::writeXml(xmlTextWriterPtr w) const
      xmlTextWriterFlush(w);
  }
- 
+
 -} // namespace pdal
 +} // namespace pdal
 \ No newline at end of file
--- 
+--
 2.39.3 (Apple Git-145)
 

--- a/recipe/patches/0001_Fix_xmlErrorPtr.patch
+++ b/recipe/patches/0001_Fix_xmlErrorPtr.patch
@@ -1,14 +1,25 @@
-From a13d70254ef1c0788f584aeb5ec25392fe9f8497 Mon Sep 17 00:00:00 2001
-From: Steven <scrass@anaconda.com>
-Date: Thu, 8 Aug 2024 10:22:57 -0600
-Subject: [PATCH] Fix convention error with xmlErrorPtr caused by libxml2 API change
+From 57031b99c610a36c31a0aefa09ee2cc4048fbc62 Mon Sep 17 00:00:00 2001
+From: aimixsaka <aimixsaka@gmail.com>
+Date: Mon, 27 Nov 2023 16:37:17 +0800
+Subject: [PATCH] Fix convention error with `xmlErrorPtr` caused by `libxml2`
+ API change
 
+Starting with `libxml2 2.12.0`, the API has changed the const-ness of the
+`xmlError` pointers, which results in a build error due to a mismatched
+type on `const xmlError *` and `xmlErrorPtr`.
+This commit papers over the difference by using preprocessor conditionals.
+
+Related libxml2 commit and issue:
+- https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7
+- https://gitlab.gnome.org/GNOME/libxml2/-/commit/61034116d0a3c8b295c6137956adc3ae55720711
+
+Fix #4255
 ---
- pdal/XMLSchema.cpp | 14 +++++++++++++-
- 1 file changed, 13 insertions(+), 1 deletion(-)
+ pdal/XMLSchema.cpp | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
 
 diff --git a/pdal/XMLSchema.cpp b/pdal/XMLSchema.cpp
-index 81d62a6..9019a06 100644
+index 81d62a61c8..9c3ae9774e 100644
 --- a/pdal/XMLSchema.cpp
 +++ b/pdal/XMLSchema.cpp
 @@ -73,7 +73,11 @@ namespace pdal
@@ -46,13 +57,3 @@ index 81d62a6..9019a06 100644
  {
      std::cerr << "Schema validation error: '" << error->message << "' " <<
          "on line " << error->line << std::endl;
-@@ -646,4 +658,4 @@ void XMLSchema::writeXml(xmlTextWriterPtr w) const
-     xmlTextWriterFlush(w);
- }
-
--} // namespace pdal
-+} // namespace pdal
-\ No newline at end of file
---
-2.39.3 (Apple Git-145)
-


### PR DESCRIPTION
pdal 2.5.3 ❄️ 

**Destination channel:** Snowflake

### Links

- [PKG-5056](https://anaconda.atlassian.net/browse/PKG-5056)
- [Fix convention error with xmlErrorPtr caused by libxml2 API change](https://github.com/PDAL/PDAL/pull/4257)

### Explanation of changes:

- Update libxml2 and libcurl pinnings
- Add patch


[PKG-5056]: https://anaconda.atlassian.net/browse/PKG-5056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-4629]: https://anaconda.atlassian.net/browse/PKG-4629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ